### PR TITLE
Disable cron job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,29 +30,29 @@ jobs:
       - store_test_results:
           path: test-results
 
-      - run:
-          name: Runs browser based tests
-          command: cd ~/tests && npm run test:ci
-
-      - store_artifacts:
-          path: test-results
-
-      - store_test_results:
-          path: test-results
+      # - run:
+      #     name: Runs browser based tests
+      #     command: cd ~/tests && npm run test:ci
+      #
+      # - store_artifacts:
+      #     path: test-results
+      #
+      # - store_test_results:
+      #     path: test-results
 
 workflows:
   version: 2
   commit-workflow:
     jobs:
       - build
-  scheduled-workflow:
-    triggers:
-      - schedule:
+  # scheduled-workflow:
+    # triggers:
+    #   - schedule:
           # Step syntax is unsupported on CircleCI
-          cron: "0,30 * * * *"
-          filters:
-            branches:
-              only: master
+          # cron: "0,30 * * * *"
+          # filters:
+          #   branches:
+          #     only: master
 
-    jobs:
-      - build
+    # jobs:
+      # - build


### PR DESCRIPTION
The automated tests are constantly failing and polluting the alerts channel. This will disable the cron job which runs them every hour.

We'll be replacing these with the acceptance test stack very shortly. In the mean time we can test the full stack locally with the acceptance tests if need be.